### PR TITLE
Used PAR to package EXE

### DIFF
--- a/mt2tbx.pl
+++ b/mt2tbx.pl
@@ -39,7 +39,11 @@ my ($dialect_name, $xcs_name, $categorial, $queue_orders, $misc); # mapping
 ### Main code ###
 
 my ($mappingFile, $xmlInput) = @ARGV;
-die ('Usage: $ perl mt2tbx.pl [JSON Mapping] [MultiTerm XML]') unless defined($mappingFile) && defined($xmlInput);
+if (!(defined($mappingFile) && defined($xmlInput)))
+{
+	print ('Usage: $ perl mt2tbx.pl [JSON Mapping] [MultiTerm XML]');
+	exit();
+}
 
 my $tbxOutput = $xmlInput =~ s/\.xml$/.tbx/ri;
 my ($volume, $directories, $tbxFile) = File::Spec->splitpath($tbxOutput);


### PR DESCRIPTION
Instead of removing XML::Rules, I used PAR to create a binary.  Also changed the how-to message to print rather than die.