### PR TITLE
Par compile

### DIFF
--- a/mt2tbx.pl
+++ b/mt2tbx.pl
@@ -23,6 +23,7 @@ use warnings;
 # data-processing libraries
 use JSON; # to read mapping
 use XML::Rules; # to map MultiTerm data to TBX
+use PerlIO::encoding;
 use Encode; # to write TBX
 use File::Spec;
 

--- a/mt2tbx.pl
+++ b/mt2tbx.pl
@@ -46,6 +46,20 @@ if (!(defined($mappingFile) && defined($xmlInput)))
 	exit();
 }
 
+#  This is specifically for the MultiTerm Converter,
+#  which has issues sending whitespace characters to the perl script.
+#  Instead of whitespace it uses "%%%%", which then needs converted back to whitespace.
+$mappingFile =~ s/%%%%/ /g;
+$xmlInput =~ s/%%%%/ /g;
+
+if (!(-e $mappingFile && -e $xmlInput))
+{
+	print("One or more of the input files do not exist:\n
+	\t$mappingFile\n
+	\t$xmlInput");
+	exit();
+}
+
 my $tbxOutput = $xmlInput =~ s/\.xml$/.tbx/ri;
 my ($volume, $directories, $tbxFile) = File::Spec->splitpath($tbxOutput);
 process_file();


### PR DESCRIPTION
compiles using PAR (with -c option).  Also adds support for the necessary whitespace replacement used by the [MT Conversion Wizard](https://github.com/byutrg/Csh-MultiTerm-TBX-Mapper).